### PR TITLE
Fix arrow key controls and center page layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3,6 +3,7 @@
 }
 
 body {
+  display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: column;

--- a/script/script.js
+++ b/script/script.js
@@ -42,13 +42,13 @@ tiles.forEach((tile, index) => {
 
 // Call move function when the arrow keys pressed
 document.addEventListener("keydown", function (event) {
-  if (event.key == "ArrowLeft" && blankIndex + 1 < boardSize) {
-    checkMoveAbility(shuffledArray[blankIndex + 1]);
+  if (event.key == "ArrowLeft" && blankIndex % degree != 0) {
+    checkMoveAbility(shuffledArray[blankIndex - 1]);
   } else if (event.key == "ArrowUp" && blankIndex + degree < boardSize) {
     checkMoveAbility(shuffledArray[blankIndex + degree]);
     console.log(blankIndex, boardSize)
-  } else if (event.key == "ArrowRight" && blankIndex - 1 >= 0) {
-    checkMoveAbility(shuffledArray[blankIndex - 1]);
+  } else if (event.key == "ArrowRight" && blankIndex % degree != degree - 1) {
+    checkMoveAbility(shuffledArray[blankIndex + 1]);
     console.log(blankIndex, boardSize)
   } else if (event.key == "ArrowDown" && blankIndex - degree >= 0) {
     checkMoveAbility(shuffledArray[blankIndex - degree]);


### PR DESCRIPTION
## Summary
- arrow left and right controls moved the wrong tiles
- body layout not centered because `display: flex` missing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684335409ecc8325942f8af95a3fcb09